### PR TITLE
Create an event when there are more than a given number of missed packets.

### DIFF
--- a/src/include/switch_core_media.h
+++ b/src/include/switch_core_media.h
@@ -92,6 +92,7 @@ typedef enum {
 
 typedef struct switch_core_media_params_s {
 	uint32_t rtp_timeout_sec;
+	uint32_t rtp_timeout_warning_event_threshold;
 	uint32_t rtp_hold_timeout_sec;
 	uint32_t dtmf_delay;
 	uint32_t codec_flags;

--- a/src/include/switch_rtp.h
+++ b/src/include/switch_rtp.h
@@ -278,8 +278,8 @@ SWITCH_DECLARE(char *) switch_rtp_get_remote_host(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(switch_port_t) switch_rtp_get_remote_port(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_reset_media_timer(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_set_max_missed_packets(switch_rtp_t *rtp_session, uint32_t max);
+SWITCH_DECLARE(void) switch_rtp_set_missed_packets_event_threshold(switch_rtp_t *rtp_session, uint32_t threshold);
 SWITCH_DECLARE(void) switch_rtp_set_media_timeout(switch_rtp_t *rtp_session, uint32_t ms);
-
 SWITCH_DECLARE(switch_status_t) switch_rtp_udptl_mode(switch_rtp_t *rtp_session);
 SWITCH_DECLARE(void) switch_rtp_reset(switch_rtp_t *rtp_session);
 

--- a/src/mod/endpoints/mod_sofia/mod_sofia.h
+++ b/src/mod/endpoints/mod_sofia/mod_sofia.h
@@ -702,6 +702,7 @@ struct sofia_profile {
 	uint32_t minimum_session_expires;
 	uint32_t max_proceeding;
 	uint32_t rtp_timeout_sec;
+	uint32_t rtp_timeout_warning_event_threshold;
 	uint32_t rtp_hold_timeout_sec;
 	char *odbc_dsn;
 	char *pre_trans_execute;

--- a/src/mod/endpoints/mod_sofia/sofia.c
+++ b/src/mod/endpoints/mod_sofia/sofia.c
@@ -5227,6 +5227,11 @@ switch_status_t config_sofia(sofia_config_t reload, char *profile_name)
 							switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 											  "rtp-timeout-sec deprecated use media_timeout variable.\n"); 
 						}
+					} else if (!strcasecmp(var, "rtp-timeout-warning-event-threshold") && !zstr(val)) {
+						int v = atoi(val);
+						if (v >= 0) {
+							profile->rtp_timeout_warning_event_threshold = v;
+						}
 					} else if (!strcasecmp(var, "rtp-hold-timeout-sec") && !zstr(val)) {
 						int v = atoi(val);
 						if (v >= 0) {

--- a/src/mod/endpoints/mod_sofia/sofia_glue.c
+++ b/src/mod/endpoints/mod_sofia/sofia_glue.c
@@ -182,6 +182,7 @@ void sofia_glue_attach_private(switch_core_session_t *session, sofia_profile_t *
 	tech_pvt->mparams.sdp_username = profile->sdp_username;
 	tech_pvt->mparams.cng_pt = tech_pvt->cng_pt;
 	tech_pvt->mparams.rtp_timeout_sec = profile->rtp_timeout_sec;
+	tech_pvt->mparams.rtp_timeout_warning_event_threshold = profile->rtp_timeout_warning_event_threshold;
 	tech_pvt->mparams.rtp_hold_timeout_sec = profile->rtp_hold_timeout_sec;
 
 	if (profile->rtp_digit_delay) {


### PR DESCRIPTION
Add to target sip_profiles as follows:

```xml
<param name="rtp-timeout-warning-event-threshold" value="300"/>
```

where the value indicates the number of missed packets upon which to trigger the event. setting it to zero unsets the event trigger.

<details><summary><strong>Example output</strong></summary>
<p>

```log
2020-03-09 00:11:31.305333 [ERR] switch_rtp.c:7290 Updated missed packets count -- total missed 300
2020-03-09 00:11:31.305333 [ERR] switch_cpp.cpp:1442 Starting event.lua script
2020-03-09 00:11:31.305333 [ERR] switch_cpp.cpp:1442 Event-Name: CUSTOM
Core-UUID: f9b2cc9a-158a-46a1-ace5-1cfa50a9903d
FreeSWITCH-Hostname: platform01
FreeSWITCH-Switchname: platform01
FreeSWITCH-IPv4: 10.243.0.200
FreeSWITCH-IPv6: %3A%3A1
Event-Date-Local: 2020-03-09%2000%3A11%3A31
Event-Date-GMT: Mon,%2009%20Mar%202020%2000%3A11%3A31%20GMT
Event-Date-Timestamp: 1583712691305333
Event-Calling-File: switch_rtp.c
Event-Calling-Function: rtp_common_read
Event-Calling-Line-Number: 7292
Event-Sequence: 710
Event-Subclass: rtp_packet_missed
caller-unique-id: 3b751258-5000-4339-84fc-6ee5880b13a4_1
caller-partner-id: 3b751258-5000-4339-84fc-6ee5880b13a4
Type: Missed

freeswitch@platform01>
freeswitch@platform01>
freeswitch@platform01>
2020-03-09 00:11:39.905343 [ERR] switch_rtp.c:7268 Starting to receive bytes again
2020-03-09 00:11:39.905343 [ERR] switch_cpp.cpp:1442 Starting event.lua script
2020-03-09 00:11:39.905343 [ERR] switch_cpp.cpp:1442 Event-Name: CUSTOM
Core-UUID: f9b2cc9a-158a-46a1-ace5-1cfa50a9903d
FreeSWITCH-Hostname: platform01
FreeSWITCH-Switchname: platform01
FreeSWITCH-IPv4: 10.243.0.200
FreeSWITCH-IPv6: %3A%3A1
Event-Date-Local: 2020-03-09%2000%3A11%3A39
Event-Date-GMT: Mon,%2009%20Mar%202020%2000%3A11%3A39%20GMT
Event-Date-Timestamp: 1583712699905343
Event-Calling-File: switch_rtp.c
Event-Calling-Function: rtp_common_read
Event-Calling-Line-Number: 7270
Event-Sequence: 720
Event-Subclass: rtp_packet_missed
caller-unique-id: 3b751258-5000-4339-84fc-6ee5880b13a4_1
caller-partner-id: 3b751258-5000-4339-84fc-6ee5880b13a4
Type: Resumed

freeswitch@platform01>
```

</p>
</details>
